### PR TITLE
fix: remove a useless require('ejs')

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -3,7 +3,6 @@
 var fs = require('fs');
 var yeoman = require('yeoman-generator');
 var yosay = require('yosay');
-var ejs = require('ejs');
 
 
 


### PR DESCRIPTION
The "require" was causing an node error on some environnements
because ejs is not declared as a dependency, and thus does not
exist.

For the record, the error is:

```
$ yo react-boilerplate-vtech
module.js:327
    throw err;
    ^

Error: Cannot find module 'ejs'
    at Function.Module._resolveFilename (module.js:325:15)
    at Function.Module._load (module.js:276:25)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/home/ubuntu/.nvm/versions/node/v4.4.3/lib/node_modules/generator-react-boilerplate-vtech/generators/app/index.js:6:11)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
```
