### PR TITLE
tell stylelint we use Sass

### DIFF
--- a/generators/app/templates/webpack.config.dev.js
+++ b/generators/app/templates/webpack.config.dev.js
@@ -22,7 +22,8 @@ config.module.preLoaders = [{
  */
 config.plugins.push(
 	new StyleLintPlugin({
-		failOnError: false
+		failOnError: false,
+		syntax: 'scss'
 	}),
 	new BrowserSyncPlugin({
 		host: 'localhost',


### PR DESCRIPTION
without setting this, there are a few errors when linting files with '//' comments for example.
