### PR TITLE
adding single-file generators for sagas, reducers, actions & components

### DIFF
--- a/generators/action/index.js
+++ b/generators/action/index.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var SimpleFileGenerator = require('../../util/SimpleFileGenerator');
+
+
+
+module.exports = SimpleFileGenerator.extend({
+	_fileCategory: 'action',
+	_destinationDefaultFolder: 'js/actions',
+
+	prompting: function() {
+		SimpleFileGenerator.prototype.prompting.apply(this, arguments);
+	},
+
+	writing: function() {
+		SimpleFileGenerator.prototype.writing.apply(this, arguments);
+	}
+});

--- a/generators/action/templates/file.js
+++ b/generators/action/templates/file.js
@@ -1,0 +1,9 @@
+export const EXAMPLE_TYPE = '<%= name %>/EXAMPLE_TYPE';
+
+
+
+export const sampleAction = () => ({
+	type: EXAMPLE_TYPE,
+	payload: {
+	}
+});

--- a/generators/container/index.js
+++ b/generators/container/index.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var SimpleFileGenerator = require('../../util/SimpleFileGenerator');
+var _ = require('lodash');
+var path = require('path');
+
+
+
+module.exports = SimpleFileGenerator.extend({
+	_fileCategory: 'container',
+	_destinationDefaultFolder: 'js/components',
+
+	prompting: function() {
+		SimpleFileGenerator.prototype.prompting.apply(this, arguments);
+	},
+
+	writing: function() {
+		this.props.component = _.upperFirst(this.props.name);
+		this._destinationFile = path.join(this.props.directory, this.props.component + 'Container.js');
+
+		SimpleFileGenerator.prototype.writing.apply(this, arguments);
+	}
+});

--- a/generators/container/templates/file.js
+++ b/generators/container/templates/file.js
@@ -1,0 +1,19 @@
+import {connect} from 'react-redux';
+import <%= component %> from './<%= component %>';
+
+
+
+const mapStateToProps = (state) => ({
+});
+
+
+
+const mapDispatchToProps = (dispatch) => ({
+});
+
+
+
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)(<%= component %>);

--- a/generators/reducer/index.js
+++ b/generators/reducer/index.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var SimpleFileGenerator = require('../../util/SimpleFileGenerator');
+
+
+
+module.exports = SimpleFileGenerator.extend({
+	_fileCategory: 'reducer',
+	_destinationDefaultFolder: 'js/reducers',
+
+	prompting: function() {
+		SimpleFileGenerator.prototype.prompting.apply(this, arguments);
+	},
+
+	writing: function() {
+		SimpleFileGenerator.prototype.writing.apply(this, arguments);
+	}
+});

--- a/generators/reducer/templates/file.js
+++ b/generators/reducer/templates/file.js
@@ -1,0 +1,21 @@
+import {AN_ACTION} from '../actions/<%= name %>';
+
+
+
+const initialState = {
+};
+
+
+
+export default function <%= name %>(state = initialState, {type, payload}) {
+	switch (type) {
+		case AN_ACTION:
+			return {
+				...state,
+				something: payload.something
+			};
+
+		default:
+			return state;
+	}
+}

--- a/generators/saga/index.js
+++ b/generators/saga/index.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var SimpleFileGenerator = require('../../util/SimpleFileGenerator');
+
+
+
+module.exports = SimpleFileGenerator.extend({
+	_fileCategory: 'saga',
+	_destinationDefaultFolder: 'js/sagas',
+
+	prompting: function() {
+		SimpleFileGenerator.prototype.prompting.apply(this, arguments);
+	},
+
+	writing: function() {
+		SimpleFileGenerator.prototype.writing.apply(this, arguments);
+	}
+});

--- a/generators/saga/templates/file.js
+++ b/generators/saga/templates/file.js
@@ -1,0 +1,19 @@
+import {takeEvery, takeLatest} from 'redux-saga';
+import {call, put} from 'redux-saga/effects';
+import {AN_ACTION, anotherAction} from '../actions/<%= name %>';
+import {apiFunction} from '../api/<%= name %>';
+
+
+
+function* somethingWorker({type, payload}) {
+	const apiResults = yield call(
+		apiFunction,
+		payload.id
+	);
+
+	yield put(anotherAction(apiResults));
+}
+
+export function* watchSomething() {
+	yield* takeLatest(AN_ACTION, somethingWorker);
+}

--- a/generators/view/index.js
+++ b/generators/view/index.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var SimpleFileGenerator = require('../../util/SimpleFileGenerator');
+var _ = require('lodash');
+var path = require('path');
+
+
+
+module.exports = SimpleFileGenerator.extend({
+	_fileCategory: 'view',
+	_destinationDefaultFolder: 'js/components',
+
+	prompting: function() {
+		SimpleFileGenerator.prototype.prompting.apply(this, arguments);
+	},
+
+	writing: function() {
+		this.props.component = _.upperFirst(this.props.name);
+		this._destinationFile = path.join(this.props.directory, this.props.component + '.js');
+
+		SimpleFileGenerator.prototype.writing.apply(this, arguments);
+	}
+});

--- a/generators/view/templates/file.js
+++ b/generators/view/templates/file.js
@@ -1,0 +1,24 @@
+import React, {PropTypes} from 'react';
+import {FormattedMessage, injectIntl} from 'react-intl';
+
+
+
+/**
+ *
+ */
+function <%= component %>({}) {
+	return (
+	);
+}
+
+
+
+<%= component %>.defaultProps = {
+};
+
+<%= component %>.propTypes = {
+};
+
+
+
+export default injectIntl(<%= component %>);

--- a/util/SimpleFileGenerator.js
+++ b/util/SimpleFileGenerator.js
@@ -1,0 +1,93 @@
+'use strict';
+
+var _ = require('lodash');
+var fs = require('fs');
+var path = require('path');
+var yeoman = require('yeoman-generator');
+var pathUtil = require('./path');
+
+
+
+/**
+ *
+ */
+module.exports = yeoman.Base.extend({
+	_fileCategory: null,
+	_destinationDefaultFolder: null,
+	_templateFile: 'file.js',
+
+	constructor: function() {
+		yeoman.Base.apply(this, arguments);
+
+		if (this._destinationDefaultFolder === null) {
+			this._destinationDefaultFolder = 'js/' + this._fileCategory;
+		}
+
+		this.argument('name', {
+			desc: 'Name of the ' + this._fileCategory + ' file',
+			required: false,
+			optional: true,
+			type: String
+		});
+
+		if (this.name) {
+			this.props = _.assign({}, this.props || {}, {
+				name: this.name
+			});
+		}
+	},
+
+	prompting: function() {
+		this.log('This generator creates a base ' + this._fileCategory + ' file for you.');
+		this.log('\n');
+
+		var that = this;
+		var done = this.async();
+
+		var relativeDestination = pathUtil.relativeToCwd(this.destinationPath());
+		var prompts = [];
+		if (!this.name) {
+			prompts.push({
+				type: 'input',
+				name: 'name',
+				message: 'Name of the ' + this._fileCategory + ' file?',
+				filter: function(userInput) {
+					if (_.endsWith('.js')) {
+						return userInput.substr(0, userInput.length - 3);
+					}
+					return userInput;
+				}
+			});
+		}
+		prompts.push({
+			type: 'input',
+			name: 'directory',
+			message: 'Folder of the ' + this._fileCategory + ' file (relative to ' + relativeDestination + ')?',
+			default: this._destinationDefaultFolder,
+			validate: function(userInput) {
+				if (fs.statSync(that.destinationPath(userInput)).isDirectory()) {
+					return true;
+				}
+				return 'The given folder path `' + userInput +' doesn\'t seem to exist';
+			}
+		});
+
+		this.prompt(prompts, function(props) {
+			this.props = _.assign({}, this.props, props);
+			done();
+		}.bind(this));
+	},
+
+	writing: function() {
+
+		if (!this._destinationFile) {
+			this._destinationFile = path.join(this.props.directory, this.props.name + '.js');
+		}
+
+		this.fs.copyTpl(
+			this.templatePath(this._templateFile),
+			this.destinationPath(this._destinationFile),
+			this.props
+		);
+	}
+});

--- a/util/path.js
+++ b/util/path.js
@@ -1,0 +1,10 @@
+var process = require('process');
+var path = require('path');
+
+
+
+module.exports = {
+	relativeToCwd: function(pathname) {
+		return './' + path.relative(process.cwd(), pathname);
+	}
+};


### PR DESCRIPTION
- use `yo react-boilerplate-vtech:saga [name]` to generate a sample sagas file
- use `yo react-boilerplate-vtech:reducer [name]` to generate a sample reducer
  file
- use `yo react-boilerplate-vtech:action [name]` to generate a sample action
  file
- use `yo react-boilerplate-vtech:container [name]` to generate a sample container component
  file
- use `yo react-boilerplate-vtech:view [name]` to generate a sample view component file

Don't know why (tested only on my home machine), but the command always take a few seconds of doing... nothing before prompting the user. Well, same thing for the default generator already there but... We might want to check on that before merging? It's really annoying °_°

@TODO:
- have a command that generates all 3 action+reducer+saga at the same time?
- being able to pass the directory directly instead of always asking?
- being able to detect where were the original
  folders created with `yo react-boilerplate-vtech` to show this as
  default, instead of guessing `js/[actions|reducers|sagas|components]`.
